### PR TITLE
Add some methods to iclient interface

### DIFF
--- a/services/base_service.go
+++ b/services/base_service.go
@@ -19,6 +19,9 @@ type IClient interface {
 	Patch(requestParams RequestParams) (*http.Response, error)
 	Put(requestParams RequestParams) (*http.Response, error)
 	Delete(requestParams RequestParams) (*http.Response, error)
+	GetDefaultTenant() string
+	GetURL(serviceCluster string) *url.URL
+	BuildHost(serviceCluster string, appendToHost string) string
 }
 
 // RequestParams contains all the optional request URL parameters


### PR DESCRIPTION
the iclient interface is missing some methods defined on the `BaseClient` in the go-sdk which makes them inaccessible for end users. for example https://cd.splunkdev.com/devplat-pr-32/splunk-cloud-sdk-go/-/blob/develop/services/client.go#L448

